### PR TITLE
Fix Parsing of JSON Literals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ endif()
 if (NOT WIN32)
     target_link_libraries("${CJSON_LIB}" m)
 endif()
+target_include_directories(${CJSON_LIB} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/library_config/libcjson.pc.in"
     "${CMAKE_CURRENT_BINARY_DIR}/libcjson.pc" @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.3)
 
 project(cJSON C)
 

--- a/cJSON.c
+++ b/cJSON.c
@@ -1062,7 +1062,7 @@ static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
         return NULL;
     }
 
-    if (can_access_at_index(buffer, 4) && (strncmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0))
+    if (can_access_at_index(buffer, 4) && (strcmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF") == 0))
     {
         buffer->offset += 3;
     }
@@ -1312,21 +1312,21 @@ static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buf
 
     /* parse the different types of values */
     /* null */
-    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "null", 4) == 0))
+    if (can_read(input_buffer, 4) && (strcmp((const char*)buffer_at_offset(input_buffer), "null") == 0))
     {
         item->type = cJSON_NULL;
         input_buffer->offset += 4;
         return true;
     }
     /* false */
-    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
+    if (can_read(input_buffer, 5) && (strcmp((const char*)buffer_at_offset(input_buffer), "false") == 0))
     {
         item->type = cJSON_False;
         input_buffer->offset += 5;
         return true;
     }
     /* true */
-    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
+    if (can_read(input_buffer, 4) && (strcmp((const char*)buffer_at_offset(input_buffer), "true") == 0))
     {
         item->type = cJSON_True;
         item->valueint = 1;

--- a/cJSON.c
+++ b/cJSON.c
@@ -1062,7 +1062,7 @@ static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
         return NULL;
     }
 
-    if (can_access_at_index(buffer, 4) && (strcmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF") == 0))
+    if (can_access_at_index(buffer, 4) && (strncmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0))
     {
         buffer->offset += 3;
     }
@@ -1312,21 +1312,21 @@ static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buf
 
     /* parse the different types of values */
     /* null */
-    if (can_read(input_buffer, 4) && (strcmp((const char*)buffer_at_offset(input_buffer), "null") == 0))
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "null", 4) == 0))
     {
         item->type = cJSON_NULL;
         input_buffer->offset += 4;
         return true;
     }
     /* false */
-    if (can_read(input_buffer, 5) && (strcmp((const char*)buffer_at_offset(input_buffer), "false") == 0))
+    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
     {
         item->type = cJSON_False;
         input_buffer->offset += 5;
         return true;
     }
     /* true */
-    if (can_read(input_buffer, 4) && (strcmp((const char*)buffer_at_offset(input_buffer), "true") == 0))
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
     {
         item->type = cJSON_True;
         item->valueint = 1;

--- a/fuzzing/afl.c
+++ b/fuzzing/afl.c
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
         goto cleanup;
     }
 
-    if ((argc == 3) && (strncmp(argv[2], "yes", 3) == 0))
+    if ((argc == 3) && (strcmp(argv[2], "yes") == 0))
     {
         int do_format = 0;
         if (json[1] == 'f')


### PR DESCRIPTION
This reverts commit ace4a1eb933d0dea46d5c05aa887d57fe09d1a8b.

This commit changed the literal parsing behavior, which was which was causing literals to fail to match the provided fixed strings.

